### PR TITLE
Replace the unmaintained typed_struct with typedstruct

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # OpenApiSpexTypedStruct [![CI](https://github.com/surrsurus/open_api_spex_typed_struct/actions/workflows/ci.yml/badge.svg)](https://github.com/surrsurus/open_api_spex_typed_struct/actions/workflows/ci.yml) [![Hex.pm](https://img.shields.io/hexpm/v/open_api_spex_typed_struct.svg)](https://hex.pm/packages/open_api_spex_typed_struct)
 
-Automatically generate api specs for your typed structs. 
+Automatically generate api specs for your typed structs.
 
-This library is a plugin for [OpenApiSpex](https://github.com/open-api-spex/open_api_spex) that allows you to define typed structs and have the schema automatically generated for you. You can then easily reference these schemas in your OpenApiSpex operations. This allows you to keep your api specs in sync with your typed structs without having to constantly update two different versions of what is effectively the same schema. 
+This library is a plugin for [OpenApiSpex](https://github.com/open-api-spex/open_api_spex) that allows you to define typed structs and have the schema automatically generated for you. You can then easily reference these schemas in your OpenApiSpex operations. This allows you to keep your api specs in sync with your typed structs without having to constantly update two different versions of what is effectively the same schema.
 
 - Give your struct a title and you're all set, the rest is generated for you.
 - You can optionally give `default` values to your fields and they will also be included in the schema.
@@ -17,7 +17,7 @@ defmodule MySpec do
   use TypedStruct
 
   typedstruct do
-    plugin TypedSpec, title: "my spec"
+    plugin(OpenApiSpexTypedStruct, title: "my spec", description: "my description")
     field :id, :string, default: "123", example: "456"
     field :qty, :integer
     field :other_schema, :object, property: MyOtherSchema
@@ -35,6 +35,7 @@ Generates a schema that looks like:
   },
   required: [:id, :qty],
   title: "my spec",
+  description: "my description"
   type: :object
 }
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,7 @@ defmodule OpenApiSpexTypedStruct.MixProject do
     [
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
       {:open_api_spex, "~> 3.16"},
-      {:typed_struct, "~> 0.3.0"}
+      {:typedstruct, github: "saleyn/typedstruct", tag: "0.5.3", override: true},
     ]
   end
 

--- a/mix.lock
+++ b/mix.lock
@@ -10,5 +10,5 @@
   "plug": {:hex, :plug, "1.15.3", "712976f504418f6dff0a3e554c40d705a9bcf89a7ccef92fc6a5ef8f16a30a97", [:mix], [{:mime, "~> 1.0 or ~> 2.0", [hex: :mime, repo: "hexpm", optional: false]}, {:plug_crypto, "~> 1.1.1 or ~> 1.2 or ~> 2.0", [hex: :plug_crypto, repo: "hexpm", optional: false]}, {:telemetry, "~> 0.4.3 or ~> 1.0", [hex: :telemetry, repo: "hexpm", optional: false]}], "hexpm", "cc4365a3c010a56af402e0809208873d113e9c38c401cabd88027ef4f5c01fd2"},
   "plug_crypto": {:hex, :plug_crypto, "2.1.0", "f44309c2b06d249c27c8d3f65cfe08158ade08418cf540fd4f72d4d6863abb7b", [:mix], [], "hexpm", "131216a4b030b8f8ce0f26038bc4421ae60e4bb95c5cf5395e1421437824c4fa"},
   "telemetry": {:hex, :telemetry, "1.2.1", "68fdfe8d8f05a8428483a97d7aab2f268aaff24b49e0f599faa091f1d4e7f61c", [:rebar3], [], "hexpm", "dad9ce9d8effc621708f99eac538ef1cbe05d6a874dd741de2e689c47feafed5"},
-  "typed_struct": {:hex, :typed_struct, "0.3.0", "939789e3c1dca39d7170c87f729127469d1315dcf99fee8e152bb774b17e7ff7", [:mix], [], "hexpm", "c50bd5c3a61fe4e198a8504f939be3d3c85903b382bde4865579bc23111d1b6d"},
+  "typedstruct": {:git, "https://github.com/saleyn/typedstruct.git", "f649974d8fa62a8b2f3780be9bc6eec07903bb8e", [tag: "0.5.3"]},
 }


### PR DESCRIPTION
For the moment, typedstruct has a glitch that forces it to be referenced this way. He's fixed it and I think just needs to push it to hex.

Also updated the readme